### PR TITLE
feat(v2): scopes

### DIFF
--- a/src/main/java/tech/thatgravyboat/repolib/v2/RepoConstants.java
+++ b/src/main/java/tech/thatgravyboat/repolib/v2/RepoConstants.java
@@ -24,29 +24,45 @@ public final class RepoConstants implements StructValue.Forwarding {
 
 
         builder.function("include", function -> {
-            function.arity(1);
+            function.arity(1, 2);
+            function.vararg(true);
             function.execute((evaluator, args) -> {
                 var value = evaluator.getStringOrThrow(args.getFirst());
                 var requested = loader.getModule(value);
                 if (requested == null) {
                     return evaluator.panic("Requested include " + value + " doesn't exist!");
                 }
-                return evaluator.pushPop(value, () -> {
-                    evaluator.evaluate(requested);
-                    return Value.NIL;
-                });
+
+                if (args.size() == 2) {
+                    var scope = evaluator.getMutableStructOrThrow(args.get(1));
+                    return evaluator.pushPop(value, scope, () -> {
+                        evaluator.evaluate(requested);
+                        return Value.NIL;
+                    });
+                } else {
+                    return evaluator.pushPop(value, () -> {
+                        evaluator.evaluate(requested);
+                        return Value.NIL;
+                    });
+                }
             });
         });
 
         builder.function("call", function -> {
-            function.arity(1);
+            function.arity(1, 2);
+            function.vararg(true);
             function.execute((evaluator, args) -> {
                 var value = evaluator.getStringOrThrow(args.getFirst());
                 var requested = loader.getModule(value);
                 if (requested == null) {
                     return evaluator.panic("Requested include " + value + " doesn't exist!");
                 }
-                return evaluator.pushPop(value, () -> evaluator.evaluate(requested));
+                if (args.size() == 2) {
+                    var scope = evaluator.getMutableStructOrThrow(args.get(1));
+                    return evaluator.pushPop(value, scope, () -> evaluator.evaluate(requested));
+                } else {
+                    return evaluator.pushPop(value, () -> evaluator.evaluate(requested));
+                }
             });
         });
 

--- a/src/main/java/tech/thatgravyboat/repolib/v2/builtin/Constants.java
+++ b/src/main/java/tech/thatgravyboat/repolib/v2/builtin/Constants.java
@@ -1,4 +1,4 @@
-wpackage tech.thatgravyboat.repolib.v2.builtin;
+package tech.thatgravyboat.repolib.v2.builtin;
 
 import org.jetbrains.annotations.NotNull;
 import tech.thatgravyboat.repolib.v2.expl.Evaluator;

--- a/src/main/java/tech/thatgravyboat/repolib/v2/builtin/Constants.java
+++ b/src/main/java/tech/thatgravyboat/repolib/v2/builtin/Constants.java
@@ -110,19 +110,23 @@ public record Constants(Map<String, Value> map) implements StructValue {
         }
 
         public static class FunctionBuilder {
-            private int arity = 0;
+            private int arityMin = 0;
+            private int arityMax = Short.MAX_VALUE;
             private boolean vararg = false;
             private BiFunction<Evaluator, List<Value>, Value> executor;
 
             public static FunctionValue create(Consumer<FunctionBuilder> builderConsumer) {
                 var builder = new FunctionBuilder();
                 builderConsumer.accept(builder);
-                int arity = builder.arity;
+                int arityMin = builder.arityMin;
+                int arityMax = builder.arityMax;
                 boolean vararg = builder.vararg;
                 var executor = builder.executor;
                 return ((evaluator, args) -> {
-                    if ((vararg && args.size() < arity) || (!vararg && args.size() != arity)) {
-                        evaluator.error("Arity mismatched, expected " + arity + " arguments but got " + args.size());
+                    if ((vararg && (args.size() > arityMax || args.size() < arityMin)) || (!vararg && args.size() != arityMin)) {
+                        evaluator.error("Arity mismatched, expected " + arityMin + (arityMin != arityMax ?
+                                " - " + arityMax :
+                                "") + " arguments but got " + args.size());
                         return NIL;
                     }
 
@@ -138,7 +142,19 @@ public record Constants(Map<String, Value> map) implements StructValue {
                 if (arity < 0) {
                     throw new IllegalArgumentException("Arity " + arity + "out of range [0;[");
                 }
-                this.arity = arity;
+                arityMin = arity;
+                arityMax = Short.MAX_VALUE;
+            }
+
+            public void arity(int arityMin, int arityMax) {
+                if (arityMax <= arityMin) {
+                    throw new IllegalArgumentException("Max arity is below (or equal) min arity!");
+                }
+                if (arityMax < 0 || arityMin < 0) {
+                    throw new IllegalArgumentException("Arity is out of range");
+                }
+                this.arityMin = arityMin;
+                this.arityMax = arityMax;
             }
 
             public void execute(BiFunction<Evaluator, List<Value>, Value> executor) {

--- a/src/main/java/tech/thatgravyboat/repolib/v2/builtin/Constants.java
+++ b/src/main/java/tech/thatgravyboat/repolib/v2/builtin/Constants.java
@@ -1,4 +1,4 @@
-package tech.thatgravyboat.repolib.v2.builtin;
+wpackage tech.thatgravyboat.repolib.v2.builtin;
 
 import org.jetbrains.annotations.NotNull;
 import tech.thatgravyboat.repolib.v2.expl.Evaluator;
@@ -155,6 +155,7 @@ public record Constants(Map<String, Value> map) implements StructValue {
                 }
                 this.arityMin = arityMin;
                 this.arityMax = arityMax;
+                vararg = true;
             }
 
             public void execute(BiFunction<Evaluator, List<Value>, Value> executor) {

--- a/src/main/java/tech/thatgravyboat/repolib/v2/expl/Evaluator.java
+++ b/src/main/java/tech/thatgravyboat/repolib/v2/expl/Evaluator.java
@@ -2,16 +2,7 @@ package tech.thatgravyboat.repolib.v2.expl;
 
 import org.jetbrains.annotations.Contract;
 import tech.thatgravyboat.repolib.v2.expl.expression.*;
-import tech.thatgravyboat.repolib.v2.expl.value.ArrayValue;
-import tech.thatgravyboat.repolib.v2.expl.value.BoolValue;
-import tech.thatgravyboat.repolib.v2.expl.value.FunctionValue;
-import tech.thatgravyboat.repolib.v2.expl.value.ImmutableStructValue;
-import tech.thatgravyboat.repolib.v2.expl.value.KeyValue;
-import tech.thatgravyboat.repolib.v2.expl.value.MutableStructValue;
-import tech.thatgravyboat.repolib.v2.expl.value.NilValue;
-import tech.thatgravyboat.repolib.v2.expl.value.NumValue;
-import tech.thatgravyboat.repolib.v2.expl.value.StrValue;
-import tech.thatgravyboat.repolib.v2.expl.value.Value;
+import tech.thatgravyboat.repolib.v2.expl.value.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -25,16 +16,30 @@ public class Evaluator {
     private static final int MAX_ITERATIONS = Short.MAX_VALUE;
 
     public final KeyValue defaults;
+    private final Scope scope;
     public final List<ContentInfo> debugs = new ArrayList<>();
     public final LinkedList<String> fileStack = new LinkedList<>();
     public final LinkedList<String> stack = new LinkedList<>();
     public final List<ContentInfo> errors = new ArrayList<>();
 
-    public Value pushPop(String stack, Supplier<Value> supplier) {
+    public Value pushPop(String stack, MutableStructValue scope, Supplier<Value> supplier) {
         try {
+            this.scope.pushWithScope(scope);
             this.stack.addLast(stack);
             return supplier.get();
         } finally {
+            this.scope.pop();
+            this.stack.removeLast();
+        }
+    }
+
+    public Value pushPop(String stack, Supplier<Value> supplier) {
+        try {
+            this.scope.push();
+            this.stack.addLast(stack);
+            return supplier.get();
+        } finally {
+            this.scope.pop();
             this.stack.removeLast();
         }
     }
@@ -52,6 +57,7 @@ public class Evaluator {
 
     public Evaluator(KeyValue defaults) {
         this.defaults = defaults;
+        scope = new Scope(defaults);
     }
 
     public static final Evaluator CONSTANT = new Evaluator(ImmutableStructValue.EMPTY);
@@ -90,7 +96,7 @@ public class Evaluator {
     }
 
     public Value getField(String field) {
-        return defaults.get(field);
+        return scope.get().get(field);
     }
 
     public String getStringOrNull(Value value) {
@@ -144,6 +150,13 @@ public class Evaluator {
             return kv;
         }
         throw new Panic("Failed to convert " + value + " into a key value");
+    }
+
+    public MutableStructValue getMutableStructOrThrow(Value value) {
+        if (value instanceof MutableStructValue msv) {
+            return msv;
+        }
+        throw new Panic("Failed to convert " + value + " into a mutable struct");
     }
 
     public Value eval0(Expression expression) {
@@ -292,7 +305,7 @@ public class Evaluator {
         var access = assign.lhs();
         final Value field;
         if (access.lhs() == null) {
-            field = defaults;
+            field = scope.get();
         } else {
             field = eval0(access.lhs());
         }
@@ -315,7 +328,7 @@ public class Evaluator {
         var field = eval0(expression.field());
 
         if (lhs == null) {
-            return defaults.get(getStringOrThrow(field));
+            return scope.get().get(getStringOrThrow(field));
         }
         var left = eval0(lhs);
         if (left instanceof ArrayValue arrayValue && field instanceof NumValue(double value)) {
@@ -333,6 +346,28 @@ public class Evaluator {
 
         public Panic(String message) {
             super(message);
+        }
+    }
+
+    private static class Scope {
+        KeyValue defaults;
+        LinkedList<KeyValue> scopes = new LinkedList<>();
+        public Scope(KeyValue defaults) {
+            this.defaults = defaults;
+            scopes.add(defaults);
+        }
+        public KeyValue get() {
+            return scopes.getLast();
+        }
+        public void push() {
+            scopes.add(new ScopeLayeredStructValue(scopes.getLast(), new MutableStructValue()));
+        }
+        public void pushWithScope(MutableStructValue newScope) {
+            scopes.add(new ScopeLayeredStructValue(defaults, newScope));
+        }
+        public void pop() {
+            if (scopes.size() == 1) throw new IllegalStateException("Cannot pop base scope");
+            scopes.removeLast();
         }
     }
 }

--- a/src/main/java/tech/thatgravyboat/repolib/v2/expl/value/ScopeLayeredStructValue.java
+++ b/src/main/java/tech/thatgravyboat/repolib/v2/expl/value/ScopeLayeredStructValue.java
@@ -1,0 +1,33 @@
+package tech.thatgravyboat.repolib.v2.expl.value;
+
+public record ScopeLayeredStructValue(KeyValue base, MutableStructValue overlay) implements KeyValue.Mutable.Forwarding {
+
+    @Override
+    public void set(String field, Value value) {
+        if (base.contains(field)) {
+            if (base instanceof KeyValue.Mutable mutableBase) {
+                mutableBase.set(field, value);
+            }
+        } else {
+            overlay.set(field, value);
+        }
+    }
+
+    @Override
+    public boolean contains(String field) {
+        return overlay.contains(field) || base.contains(field);
+    }
+
+    @Override
+    public Value get(String field) {
+        if (overlay.contains(field)) {
+            return overlay.get(field);
+        }
+        return base.get(field);
+    }
+
+    @Override
+    public MutableStructValue delegate() {
+        return overlay;
+    }
+}


### PR DESCRIPTION
adds the ability for vararg functions to have a maximum amount of arguments  
also adds scopes  
```
if (true) {
  bool = false;
};
# bool is not defined here
```
`call` or `include` with 2 arguments treats the second argument as the new scope of the module (allowing passing of arguments)  
the new scope will not contain the variables that aren't on the global scope  
<img width="522" height="318" alt="image" src="https://github.com/user-attachments/assets/0a4dc716-0b87-4355-ba10-3752f2df181b" />
example of compact stuff with this