### PR TITLE
fix: overlay not containing a variable no longer creates it on the ba…

### DIFF
--- a/src/main/java/tech/thatgravyboat/repolib/v2/expl/Lexer.java
+++ b/src/main/java/tech/thatgravyboat/repolib/v2/expl/Lexer.java
@@ -218,7 +218,7 @@ public final class Lexer {
 
     private void consumeWhitespace() {
         boolean inComment = false;
-        while (true) {
+        while (!atEnd()) {
             if (peek0() == '#') {
                 inComment = true;
                 advance();

--- a/src/main/java/tech/thatgravyboat/repolib/v2/expl/value/ScopeLayeredStructValue.java
+++ b/src/main/java/tech/thatgravyboat/repolib/v2/expl/value/ScopeLayeredStructValue.java
@@ -20,10 +20,10 @@ public record ScopeLayeredStructValue(KeyValue base, MutableStructValue overlay)
 
     @Override
     public Value get(String field) {
-        if (overlay.contains(field)) {
-            return overlay.get(field);
+        if (!overlay.contains(field) && base.contains(field)) {
+            return base.get(field);
         }
-        return base.get(field);
+        return overlay.get(field);
     }
 
     @Override


### PR DESCRIPTION
i forgor `base.get(field)` creates a new blank object on base (which leaks a lot of variables)  
